### PR TITLE
Allow passing multiple options to grin in docker

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -41,4 +41,5 @@ RUN grin server config && \
 
 EXPOSE 13413 13414 13415 13416
 
-ENTRYPOINT ["grin", "server", "run"]
+ENTRYPOINT ["grin"]
+CMD ["server", "run"]


### PR DESCRIPTION
Docker best practice entrypoint should be the main binary, while cmd should be the default (but overrideable options). Using this patch enables using the docker image as a replacement to the `grin` binary. For example this command now works `docker run --rm -it grin wallet --help` .. Also `alias grin=docker run --rm -it grin` can be useful